### PR TITLE
Add functionality to update daily dev email on user table

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -64,6 +64,7 @@ module Admin
 
     def other_params
       %i[
+        email_daily_digest_notifications
         email_newsletter
         email_comment_notifications
         email_follower_notifications

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -9,6 +9,7 @@ class UserPolicy < ApplicationPolicy
     contact_consent
     currently_hacking_on
     currently_learning
+    email_daily_digest_notifications
     display_sponsors dribbble_url
     editor_version education email
     email_badge_notifications

--- a/app/views/users/_notifications.html.erb
+++ b/app/views/users/_notifications.html.erb
@@ -2,13 +2,12 @@
 <%= form_for(@user) do |f| %>
   <div class="checkbox-field">
     <div class="sub-field">
-      <%= f.check_box :email_newsletter %>
-      <%= f.label :email_newsletter, "Send me weekly newsletter emails" %>
+      <%= f.check_box :email_daily_digest_notifications %>
+      <%= f.label :email_daily_digest_notifications, "Send me my daily dev email" %>
     </div>
-    <!-- keyword: potato -->
     <div class="sub-field">
       <%= f.check_box :email_newsletter %>
-      <%= f.label :email_newsletter, "Send me my daily dev email" %>
+      <%= f.label :email_newsletter, "Send me weekly newsletter emails" %>
     </div>
     <div class="sub-field">
       <%= f.check_box :email_digest_periodic %>

--- a/db/migrate/20200327015128_add_email_daily_digest_notificationsto_users.rb
+++ b/db/migrate/20200327015128_add_email_daily_digest_notificationsto_users.rb
@@ -1,0 +1,5 @@
+class AddEmailDailyDigestNotificationstoUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :email_daily_digest_notifications, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_27_214321) do
+ActiveRecord::Schema.define(version: 2020_03_27_015128) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1177,6 +1177,7 @@ ActiveRecord::Schema.define(version: 2020_02_27_214321) do
     t.string "username"
     t.string "website_url"
     t.datetime "workshop_expiration"
+    t.boolean "email_daily_digest_notifications", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["created_at"], name: "index_users_on_created_at"
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,6 +32,20 @@ User.clear_index!
 
 roles = %i[trusted chatroom_beta_tester workshop_pass]
 
+User.create!(
+  name: 'Linda',
+  summary: Faker::Lorem.paragraph_by_chars(number: 199, supplemental: false),
+  profile_image: File.open(Rails.root.join("app/assets/images/#{rand(1..40)}.png")),
+  website_url: Faker::Internet.url,
+  twitter_username: Faker::Internet.username(specifier: name),
+  email_comment_notifications: false,
+  email_follower_notifications: false,
+  email_daily_digest_notifications: false,
+  email: 'yueling1222@gmail.com',
+  confirmed_at: Time.current,
+  password: "password"
+)
+
 num_users.times do |i|
   name = Faker::Name.unique.name
 

--- a/spec/system/user_signs_up_for_daily_dev_email_spec.rb
+++ b/spec/system/user_signs_up_for_daily_dev_email_spec.rb
@@ -12,13 +12,46 @@ RSpec.describe "Opts in to Daily Dev Email", type: :system do
     expect(user.email_daily_digest_notifications).to be(false)
 
     expect(page).to have_unchecked_field("Send me my daily dev email")
-
     page.check "Send me my daily dev email"
 
     click_on "SUBMIT"
+    user.reload
 
     expect(page).to have_text("Your profile was successfully updated.")
+    expect(page).to have_checked_field("Send me my daily dev email")
 
     expect(user.email_daily_digest_notifications).to be(true)
+  end
+
+  it "lets user change daily email setting" do
+    expect(user.email_daily_digest_notifications).to be(false)
+    page.check "Send me my daily dev email"
+
+    click_on "SUBMIT"
+    user.reload
+
+    expect(user.email_daily_digest_notifications).to be(true)
+
+    page.uncheck "Send me my daily dev email"
+
+    click_on "SUBMIT"
+    user.reload
+
+    expect(user.email_daily_digest_notifications).to be(false)
+  end
+
+  it "has unchecked email notification setting checkboxes" do
+    expect(page).to have_unchecked_field("Send me my daily dev email")
+    expect(page).to have_unchecked_field("Send me a periodic digest of top posts from my tags")
+  end
+
+  it "has checked email notification setting checkboxes" do
+    expect(page).to have_checked_field("Send me weekly newsletter emails")
+    expect(page).to have_checked_field("Send me an email when someone replies to me in a comment thread")
+    expect(page).to have_checked_field("Send me an email when someone new follows me")
+    expect(page).to have_checked_field("Send me an email when someone mentions me")
+    expect(page).to have_checked_field("Send me an email when I receive a badge")
+    expect(page).to have_checked_field("Send me an email when I receive a direct message (while inactive)")
+    expect(page).to have_checked_field("Send me occasional reminders that I have unread notifications on dev.to")
   end
 end

--- a/spec/system/user_signs_up_for_daily_dev_email_spec.rb
+++ b/spec/system/user_signs_up_for_daily_dev_email_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe "Opts in to Daily Dev Email", type: :system do
+  let(:user) { create(:user, saw_onboarding: true) }
+
+  before do
+    sign_in(user)
+    visit "/settings/notifications"
+  end
+
+  it "lets user sign up for daily dev email" do
+    expect(user.email_daily_digest_notifications).to be(false)
+
+    expect(page).to have_unchecked_field("Send me my daily dev email")
+
+    page.check "Send me my daily dev email"
+
+    click_on "SUBMIT"
+
+    expect(page).to have_text("Your profile was successfully updated.")
+
+    expect(user.email_daily_digest_notifications).to be(true)
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The params for the checkbox in the notification settings has been updated to match what is in the user table. Users can also now check and uncheck the box to toggle email_daily_digest_notifications from false to true and vice versa.

## Related Tickets & Documents
#28 
#30 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [X] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
